### PR TITLE
[be] Response 형식 표준화, 예외처리 진행

### DIFF
--- a/backend/psytest/.idea/vcs.xml
+++ b/backend/psytest/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+  </component>
+</project>

--- a/backend/psytest/src/main/java/com/psytest/fortuneCookie/controller/fortuneCookieController.java
+++ b/backend/psytest/src/main/java/com/psytest/fortuneCookie/controller/fortuneCookieController.java
@@ -1,9 +1,10 @@
 package com.psytest.fortuneCookie.controller;
 
+import com.psytest.fortuneCookie.dto.FortuneCookieResponse;
 import com.psytest.fortuneCookie.service.fortuneCookieService;
+import com.psytest.global.util.ResponseUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,9 +22,7 @@ public class fortuneCookieController {
     @Operation(summary = "쿠키 깨트리기", description = "쿠키를 클릭해서 행운의 문구를 볼 수 있도록 데이터베이스에서 랜덤으로 가져옵니다.")
     @PostMapping("/")
     public ResponseEntity<?> fortuneCookieOpen() {
-        String fortune = fortuneCookieService.fortuneCookieOpen();
-        return fortune!=null
-                ? ResponseEntity.ok(fortune)
-                : ResponseEntity.notFound().build();
+        FortuneCookieResponse fortuneCookieResponse = fortuneCookieService.fortuneCookieOpen();
+        return ResponseUtil.success(fortuneCookieResponse);
     }
 }

--- a/backend/psytest/src/main/java/com/psytest/fortuneCookie/dto/FortuneCookieResponse.java
+++ b/backend/psytest/src/main/java/com/psytest/fortuneCookie/dto/FortuneCookieResponse.java
@@ -1,8 +1,5 @@
 package com.psytest.fortuneCookie.dto;
 
-import lombok.Getter;
-
 public record FortuneCookieResponse(
-        Integer fortuneCookieId,
         String fortune
 ) {}

--- a/backend/psytest/src/main/java/com/psytest/fortuneCookie/service/fortuneCookieService.java
+++ b/backend/psytest/src/main/java/com/psytest/fortuneCookie/service/fortuneCookieService.java
@@ -1,10 +1,13 @@
 package com.psytest.fortuneCookie.service;
 
+import com.psytest.fortuneCookie.dto.FortuneCookieResponse;
 import com.psytest.fortuneCookie.entity.FortuneCookieEntity;
 import com.psytest.fortuneCookie.repository.fortuneCookieRepository;
-import io.swagger.v3.oas.annotations.servers.Server;
+import com.psytest.global.exception.ErrorCode;
+import com.psytest.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.Random;
@@ -16,23 +19,21 @@ public class fortuneCookieService {
 
     private final fortuneCookieRepository fortuneCookieRepository;
 
-    public String fortuneCookieOpen() {
+    public FortuneCookieResponse fortuneCookieOpen() {
         log.info("😊 포춘쿠키를 깨트립니다.");
 
         log.info("😊 랜덤 인덱스를 선택합니다.");
         Random ramdom = new Random();
-        int idx = ramdom.nextInt(500)+1;
+        int idx = ramdom.nextInt(500)+1; // 1-500 사이의 랜덤 숫자
 
         log.info("😊 행운의 문구를 가져옵니다.");
         FortuneCookieEntity fortuneCookieEntity = fortuneCookieRepository.findByFortuneCookieId(idx);
-
-        if(fortuneCookieEntity == null) {
-            log.info("😊 행운의 문구를 가져오지 못했습니다.");
-            return null;
-        }else{
-            log.info("😊 행운의 문구 : " + fortuneCookieEntity.getFortune());
-            return fortuneCookieEntity.fortune;
+        if (fortuneCookieEntity == null) {
+            log.warn("❌ fortuneCookieEntity 조회 실패. 행운의 문구를 가져오지 못했습니다. idx={}", idx);
+            throw new GlobalException(HttpStatus.NOT_FOUND, ErrorCode.DATA_NOT_FOUND);
         }
 
+        log.info("😊 행운의 문구 : " + fortuneCookieEntity.getFortune());
+        return new FortuneCookieResponse(fortuneCookieEntity.getFortune());
     }
 }

--- a/backend/psytest/src/main/java/com/psytest/global/exception/ErrorCode.java
+++ b/backend/psytest/src/main/java/com/psytest/global/exception/ErrorCode.java
@@ -1,0 +1,70 @@
+package com.psytest.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+    // ✅ 요청 관련 (E1000대)
+    BAD_REQUEST("E1001", "잘못된 요청입니다."),
+    UNAUTHORIZED("E1002", "인증이 필요합니다."),
+    FORBIDDEN("E1003", "권한이 없습니다."),
+    VALIDATION_FAILED("E1004", "요청 값 검증에 실패했습니다."),
+
+    // ✅ 시스템 내부 에러 (E2000대)
+    SYSTEM_ERROR("E2001", "시스템 에러 발생"),
+    SERVICE_UNAVAILABLE("E2002", "현재 서비스를 이용할 수 없습니다."),
+    DB_ERROR("E2003", "데이터베이스 오류가 발생했습니다."),
+
+    // ✅ 인증/인가 (E3000대)
+    INVALID_TOKEN("E3001", "토큰 유효성 검증에 실패하였습니다."),
+    TOKEN_EXPIRED("E3002", "토큰 유효기간이 만료되었습니다."),
+    INVALID_TOKEN_REQUEST("E3003", "토큰 요청 형식이 잘못되었습니다."),
+    TOKEN_ERROR("E3004", "토큰 인증에 실패하였습니다."),
+
+    // ✅ 데이터/리소스 (E4000대)
+    DATA_NOT_FOUND("E4001", "데이터 조회에 실패했습니다."),
+    DATA_SAVE_FAILED("E4002", "데이터 저장, 업데이트에 실패했습니다."),
+    DATA_DELETE_FAILED("E4003", "데이터 삭제에 실패했습니다."),
+    DATA_FORBIDDEN_ACCESS("E4004", "데이터에 대한 접근 권한이 없습니다."),
+    INVALID_PARAMETER("E4005", "파라미터 형식이 잘못되었습니다."),
+    DATA_FORBIDDEN_UPDATE("E4006", "데이터에 대한 수정/삭제 권한이 없습니다."),
+    DUPLICATE_RESOURCE("E4007", "이미 존재하는 리소스입니다."),
+
+    // ✅ 사용자 계정 (E5000대)
+    DUPLICATE_EMAIL("E5001", "이미 존재하는 이메일입니다."),
+    DUPLICATE_NICKNAME("E5002", "이미 존재하는 닉네임입니다."),
+    SEND_EMAIL_CODE_FAILED("E5003", "인증 코드 전송 실패"),
+    EMAIL_CERTIFICATION_FAILED("E5004", "이메일 인증 실패"),
+    DUPLICATE_USER("E5005", "이미 가입된 회원입니다."),
+    JOIN_SOCIAL_FAILED("E5006", "간편 회원가입 실패"),
+    USER_NOT_FOUND("E5007", "존재하지 않는 회원입니다."),
+    INVALID_EMAIL_FORMAT("E5008", "이메일 형식이 잘못되었습니다."),
+    INVALID_PASSWORD_FORMAT("E5009", "비밀번호 형식이 잘못되었습니다."),
+    INVALID_USER_INFO("E5010", "잘못된 사용자 요청입니다. 입력한 정보를 다시 확인해주세요."),
+    WITHDRAW_USER("E5011", "탈퇴한 사용자입니다."),
+    INVALID_LOGIN_EMAIL("E5012", "이메일이 잘못되었습니다."),
+
+    // ✅ 로그인 (E6000대)
+    LOGIN_FAILED("E6001", "로그인에 실패하였습니다."),
+    LOGIN_SOCIAL_FAILED("E6002", "간편 로그인 실패"),
+    INCORRECT_PASSWORD("E6003", "현재 비밀번호가 올바르지 않습니다."),
+    SAME_PASSWORD("E6004", "현재 비밀번호와 동일한 비밀번호입니다."),
+
+    // ✅ 파일/스토리지 (E7000대)
+    FILE_UPLOAD_FAILED("E7001", "파일 업로드 실패"),
+    IMAGE_ANALYZE_FAILED("E7002", "이미지 분석 실패"),
+    FILE_DELETE_IS_FAILED("E7003", "파일 삭제에 실패하였습니다."),
+    FILE_DOES_NOT_EXIST("E7004", "파일이 존재하지 않습니다."),
+    UNSUPPORTED_EXTENSION("E7005", "지원하지 않는 파일 형식입니다."),
+    INVALID_FILE_REQUEST("E7006", "잘못된 형식의 파일 요청입니다."),
+    EXTERNAL_API_ERROR("E7007", "외부 API 연동에 실패했습니다.");
+
+    private final String code;
+    private final String message;
+
+    ErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/backend/psytest/src/main/java/com/psytest/global/exception/GlobalException.java
+++ b/backend/psytest/src/main/java/com/psytest/global/exception/GlobalException.java
@@ -1,0 +1,17 @@
+package com.psytest.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GlobalException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final HttpStatus status;
+
+    public GlobalException(HttpStatus status, ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = status;
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/psytest/src/main/java/com/psytest/global/response/ResponseData.java
+++ b/backend/psytest/src/main/java/com/psytest/global/response/ResponseData.java
@@ -1,0 +1,38 @@
+package com.psytest.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL) // NULL 값이 아닌 경우에만 직렬화된 출력
+@Schema(description = "결과 공통 정보") // 스웨거 문서화 설명용
+public class ResponseData<T> {
+
+    // http 상태 코드
+    @Schema(description = "HTTP 상태코드 (예: 200, 404)")
+    @JsonProperty("httpStatus")
+    private Integer httpStatus;
+
+    // 결과 코드
+    @Schema(description = "결과 코드 (예: S0000, E3001)")
+    @JsonProperty("code")
+    private String code;
+
+    // 결과 메시지
+    @Schema(description = "결과 메시지 (예: 성공, 토큰 만료)")
+    @JsonProperty("message")
+    private String message;
+
+    // 결과 데이터
+    @Schema(description = "API 응답 데이터")
+    @JsonProperty("data")
+    private T data = null;
+}

--- a/backend/psytest/src/main/java/com/psytest/global/util/ResponseUtil.java
+++ b/backend/psytest/src/main/java/com/psytest/global/util/ResponseUtil.java
@@ -1,0 +1,58 @@
+package com.psytest.global.util;
+
+import com.psytest.global.exception.ErrorCode;
+import com.psytest.global.exception.GlobalException;
+import com.psytest.global.response.ResponseData;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseUtil {
+
+    public static <T> ResponseEntity<ResponseData<T>> success(T data) {
+        return ResponseEntity.ok(
+                ResponseData.<T>builder()
+                        .httpStatus(HttpStatus.OK.value())
+                        .code("S0000")
+                        .message("성공적으로 처리되었습니다.")
+                        .data(data)
+                        .build()
+        );
+    }
+
+    public static <T> ResponseEntity<ResponseData<T>> success() {
+        return ResponseEntity.ok(
+                ResponseData.<T>builder()
+                        .httpStatus(HttpStatus.OK.value())
+                        .code("S0000")
+                        .message("성공적으로 처리되었습니다.")
+                        .build()
+        );
+    }
+
+    public static <T> ResponseEntity<ResponseData<T>> failure(GlobalException e) {
+        return ResponseEntity.status(e.getStatus())
+                .body(ResponseData.<T>builder()
+                        .httpStatus(e.getStatus().value())
+                        .code(e.getErrorCode().getCode())
+                        .message(e.getErrorCode().getMessage())
+                        .build());
+    }
+
+    public static <T> ResponseEntity<ResponseData<T>> failure(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseData.<T>builder()
+                        .httpStatus(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                        .code(ErrorCode.SYSTEM_ERROR.getCode())
+                        .message(e.getMessage())
+                        .build());
+    }
+
+    public static <T> ResponseEntity<ResponseData<T>> failure(ErrorCode errorCode) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ResponseData.<T>builder()
+                        .httpStatus(HttpStatus.BAD_REQUEST.value())
+                        .code(errorCode.getCode())
+                        .message(errorCode.getMessage())
+                        .build());
+    }
+}


### PR DESCRIPTION
1. 반환형식 표준화
- http status와 코드, 메시지를 함께 보내도록 수정
- 전달하는 data는 DTO에 값을 담아서 묶어 전달
<img width="454" height="164" alt="image" src="https://github.com/user-attachments/assets/ba55abc4-c9df-4aff-8084-e4f52b881c82" />

2. API Response 표준화
- 성공/실패 나누고 global exception 생성
