### PR TITLE
[fe/be] 디비 연결 시간 끊어지지 않도록 수정 -> ping 컨트롤러 생성

### DIFF
--- a/backend/psytest/src/main/java/com/psytest/fortuneCookie/controller/fortuneCookieController.java
+++ b/backend/psytest/src/main/java/com/psytest/fortuneCookie/controller/fortuneCookieController.java
@@ -19,6 +19,12 @@ public class fortuneCookieController {
         this.fortuneCookieService = fortuneCookieService;
     }
 
+    @Operation(summary = "핑 보내기", description = "서버로 핑 연결을 통해 빠른 속도 유지하기")
+    @GetMapping("/ping")
+    public ResponseEntity<?> ping() {
+        return ResponseUtil.success();
+    }
+
     @Operation(summary = "쿠키 깨트리기", description = "쿠키를 클릭해서 행운의 문구를 볼 수 있도록 데이터베이스에서 랜덤으로 가져옵니다.")
     @PostMapping
     public ResponseEntity<?> fortuneCookieOpen() {

--- a/frontend/psytest/src/pages/HomePage.tsx
+++ b/frontend/psytest/src/pages/HomePage.tsx
@@ -12,7 +12,7 @@ export default function HomePage() {
   useEffect(() => {
     const warm = async () => {
       try {
-        await api.head("/fortuneCookie");
+        await api.head("/fortuneCookie/ping");
       } catch {
         // fallback: 동일 출처 루트로 아주 가벼운 GET (HTML 받지만 버림)
         fetch("/", { cache: "no-store" }).catch(() => {});


### PR DESCRIPTION
```
    @Operation(summary = "핑 보내기", description = "서버로 핑 연결을 통해 빠른 속도 유지하기")
    @GetMapping("/ping")
    public ResponseEntity<?> ping() {
        return ResponseUtil.success();
    }
```
```
  // 아주 가벼운 워밍업: 앱 진입 시 1회
  // - 우선 HEAD /fortuneCookie로 연결/스레드풀/JIT 살짝 깨움
  // - 서버가 HEAD 미지원(405)이면 / GET으로 대체(연결만 열어도 도움)
  useEffect(() => {
    const warm = async () => {
      try {
        await api.get("/fortuneCookie/ping");
      } catch {
        // fallback: 동일 출처 루트로 아주 가벼운 GET (HTML 받지만 버림)
        fetch("/", { cache: "no-store" }).catch(() => {});
      }
    };
    warm();
  }, []);
```