### PR TITLE
[be] 디비 연결 시간 끊어지지 않도록 수정

### DIFF
--- a/backend/psytest/src/main/resources/application.yml
+++ b/backend/psytest/src/main/resources/application.yml
@@ -19,11 +19,11 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 10
-      minimum-idle: 2 # 유휴 연결 3개는 항상 유지
+      minimum-idle: 5 # 유휴 연결 5개는 항상 유지
       connection-timeout: 30000
       validation-timeout: 5000
-      idle-timeout: 240000 # 4분(밀리초), DB wait_timeout보다 짧게
-      keepalive-time: 300000     # 5분마다 ping으로 연결 살리기
+      idle-timeout: 600000      # 10분 (keepalive보다 길게)
+      keepalive-time: 120000  # 2분마다 ping으로 연결 살리기
       max-lifetime: 1800000      # 30분마다 연결 순환
 
   jackson:


### PR DESCRIPTION
```
  datasource:
    url: jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true&useSSL=false
    username: ${MYSQL_USER}
    password: ${MYSQL_PASSWORD}
    driver-class-name: com.mysql.cj.jdbc.Driver
    hikari:
      maximum-pool-size: 10
      minimum-idle: 5 # 유휴 연결 5개는 항상 유지
      connection-timeout: 30000
      validation-timeout: 5000
      idle-timeout: 600000      # 10분 (keepalive보다 길게)
      keepalive-time: 120000  # 2분마다 ping으로 연결 살리기
      max-lifetime: 1800000      # 30분마다 연결 순환
```